### PR TITLE
Feature/with message util

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,12 @@ import { pipeValidators, rules } from '@codeparticle/formal';
 const { isString, minLength } = rules;
 
 // ...
-const longString = pipeValidators(isString, minLength(50));
+const isLongString = pipeValidators(isString, minLength(50));
 
-longList
-  .filter((val) => longString(val).isSuccess)
+values
+  .filter((val) => isLongString(val).isSuccess)
   .map((container) => container.value)
-  .map((longString) => console.log(longString));
+  .map((str) => console.log(str));
 
 // this technique can make testing a breeze.
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ import {
 
 Sometimes, the messages included with built-in or existing checks need to be modified after the fact. Formal supports this via the `withMessage` function.
 
+`withMessage` creates a new copy of the rule, so don't worry about accidentally overwriting something important when using it. Like `createRule`, you can supply a string, or a function that returns a string.
+
 ```ts
 import { withMessage, rules } from '@codeparticle/formal';
 
@@ -133,13 +135,19 @@ const withInternationalizedErrorMessage = withMessage(
   intl.formatMessage('form.error.message')
 );
 
+const withNewMessageFn = withMessage(
+  (badValue) => `${badValue} is invalid for this field.`
+);
+
 const adminFormFieldCheck = withAdminFormErrorMessage(rules.isString);
 
 const userFormFieldCheck = withUserFormErrorMessage(rules.isString);
 
-const internationalizedErrorMessage = withInternationalizedErrorMessage(
+const internationalizedFieldCheck = withInternationalizedErrorMessage(
   rules.isString
 );
+
+const customMessageFunctionFieldCheck = withNewMessageFn(rules.isString);
 ```
 
 ## Creating your own validators

--- a/README.md
+++ b/README.md
@@ -48,6 +48,44 @@ invalidResult.then({
 });
 ```
 
+formal is flexible to your style, and exposes a `pipeValidators` function for writing validations in a more functional way. It condenses multiple checks into a function that encloses a value into a `Success` or `Fail` container.
+
+Once run, these validation containers are supplied with an `isSuccess` property for use in filters,with the ability to reach for the internally held `value`. While not recommended for control flow, it's useful in cases where you're running validation over a long list of items, as well as in writing test cases.
+
+```ts
+import { pipeValidators, rules } from '@codeparticle/formal';
+const { isString, minLength } = rules;
+
+// ...
+const longString = pipeValidators(isString, minLength(50));
+
+longList
+  .filter((val) => longString(val).isSuccess)
+  .map((container) => container.value)
+  .map((longString) => console.log(longString));
+
+// this technique can make testing a breeze.
+
+// here, we want all of our objects to have a common property; maybe a required prop in a react component.
+
+// while a bit contrived here, this method makes tests over complex, nested objects
+// or other data simple to do.
+
+const testObjects = [
+  { required: 'present' },
+  { required: 'present' },
+  { required: 'wrong' },
+];
+
+const check = pipeValidators(isObject, getProp('required'));
+
+for (const test of testObjects) {
+  expect(check(test).isSuccess).toBe(true); // passes
+
+  expect(check(test).value).toBe('present'); // fails
+}
+```
+
 ### Built-in Validators
 
 Formal has a small set of useful checks built in to validate simple data.
@@ -77,6 +115,33 @@ import {
 ...
 ```
 
+### Customizing built-in or existing checks
+
+Sometimes, the messages included with built-in or existing checks need to be modified after the fact. Formal supports this via the `withMessage` function.
+
+```ts
+import { withMessage, rules } from '@codeparticle/formal';
+
+const withAdminFormErrorMessage = withMessage(
+  `Admins must enter an administrator ID.`
+);
+const withUserFormErrorMessage = withMessage(
+  `Users must enter their first and last name to sign up`
+);
+
+const withInternationalizedErrorMessage = withMessage(
+  intl.formatMessage('form.error.message')
+);
+
+const adminFormFieldCheck = withAdminFormErrorMessage(rules.isString);
+
+const userFormFieldCheck = withUserFormErrorMessage(rules.isString);
+
+const internationalizedErrorMessage = withInternationalizedErrorMessage(
+  rules.isString
+);
+```
+
 ## Creating your own validators
 
 Formal gives you the ability to create your own rules to supply to `Validator`. There are two ways to do so.
@@ -94,22 +159,22 @@ export const containsMatchingString = (match) =>
   });
 ```
 
-Formal also allows more customized checks by exposing `Success` and `Fail`. These are useful in cases where you want to do something when you want to change the output, such as drilling down through nested properties while checking that they exist first.
+createRule also allows more customized checks through an optional parameter called `transform`
+that allows for a transformation of the value _before_ it's handed off to the next validation check.
 
 ```ts
-import { Success, Fail } from '@codeparticle/formal';
+import { createRule } from '../rule';
+import { hasProp } from './has-prop';
 
-export const getProp = (propName) => (obj) => {
-  if (typeof obj !== 'object') {
-    return Fail.of('Value is not an object.');
-  }
-
-  if (obj.hasOwnProperty(propName)) {
-    return Success.of(obj[propName]);
-  }
-
-  return Fail.of(`Object does not contain property "${propName}"`);
-};
+// below is the actual source code of the built-in getProp function
+export const getProp = (property) =>
+  createRule({
+    condition: (obj) => hasProp(property).check(obj).isSuccess,
+    message: `Property '${property}' does not exist`,
+    // transform the object to the value of the successfully found property
+    // before handing off to the next check / function.
+    transform: (obj) => obj[property],
+  });
 ```
 
 ## Usage with Typescript
@@ -129,6 +194,8 @@ import {
   ValidationM,
   // aliases for a single or array of validation rules provided to Validator.of
   ValidationRule,
+  // alias for a function that returns a Success or Failure.
+  ValidationCheck,
   ValidationRuleSet,
   // interface for the Validator class
   Validator,

--- a/src/__tests__/Validation.test.ts
+++ b/src/__tests__/Validation.test.ts
@@ -1,4 +1,9 @@
+/**
+ * @file Unit tests for @codeparticle/formal
+ */
+
 import { test } from 'shelljs';
+import { createRule, withMessage } from '../rule';
 import { getProp, isNumber, isObject, isString } from '../rules';
 import { id } from '../utils';
 import { Validator } from '../validation';
@@ -63,5 +68,29 @@ describe('Validation', () => {
     expect(failedNumber.then(testOpts)).toMatchObject([
       'Value wow is not a number.',
     ]);
+  });
+});
+
+describe('Rule', () => {
+  const customRule = createRule({
+    condition: (val) => val > 3,
+    message: 'value must be greater than 3',
+  });
+  it('allows for initialization through createRule', () => {
+    expect(customRule.check(3).isSuccess).toBe(false);
+    expect(customRule.check(5).isSuccess).toBe(true);
+    expect(customRule.check(3).value[0]).toBe('value must be greater than 3');
+  });
+
+  it('allows for overwriting the message of an existing rule using withMessage', () => {
+    const overwriteText = withMessage('Whoa');
+    const newRule = overwriteText(customRule);
+    const overwriteFn = withMessage((d) => `Man, that's a crooked ${d}`);
+
+    expect(newRule.check(2).isSuccess).toBe(false);
+    expect(newRule.check(2).value[0]).toBe('Whoa');
+    expect(overwriteFn(newRule).check(2).value[0]).toBe(
+      "Man, that's a crooked 2"
+    );
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,16 @@
 import { Fail } from './fail';
+import { createRule, withMessage } from './rule';
 import * as rules from './rules';
 import { Success } from './success';
 import { pipeValidators } from './utils';
-import { createRule, Validator } from './validation';
+import { Validator } from './validation';
 
-export { Success, Fail, Validator, createRule, pipeValidators, rules };
+export {
+  Success,
+  Fail,
+  Validator,
+  createRule,
+  withMessage,
+  pipeValidators,
+  rules,
+};

--- a/src/rule.ts
+++ b/src/rule.ts
@@ -29,11 +29,9 @@ class Rule implements ValidationRule {
 
       return Success.of(value);
     } else {
-      if (typeof this.opts.message === 'function') {
-        return Fail.of(this.opts.message(value));
-      }
-
-      return Fail.of(this.opts.message);
+      return typeof this.opts.message === 'function'
+        ? Fail.of(this.opts.message(value))
+        : Fail.of(this.opts.message);
     }
   };
 }

--- a/src/rule.ts
+++ b/src/rule.ts
@@ -1,0 +1,62 @@
+/**
+ * @file Rule class for use with createRule and withMessage
+ * @author Nick Krause
+ */
+import { Fail } from './fail';
+import { Success } from './success';
+import {
+  CustomValidatorOptions,
+  ValidationCheck,
+  ValidationRule,
+} from './types';
+
+class Rule implements ValidationRule {
+  message: string | ((v: any) => string);
+  opts: CustomValidatorOptions;
+
+  constructor(opts: CustomValidatorOptions) {
+    this.opts = opts;
+  }
+
+  check: ValidationCheck = (value) => {
+    if (this.opts.condition(value)) {
+      // Rule and createRule accept an optional function (delayed) parameter
+      // called transform that allows us to change the value
+      // before it is passed onto the next check.
+      if (this.opts.transform) {
+        return Success.of(this.opts.transform(value));
+      }
+
+      return Success.of(value);
+    } else {
+      if (typeof this.opts.message === 'function') {
+        return Fail.of(this.opts.message(value));
+      }
+
+      return Fail.of(this.opts.message);
+    }
+  };
+}
+
+/**
+ * Exposed interface to create a rule
+ */
+const createRule: (opts: CustomValidatorOptions) => ValidationRule = (opts) => {
+  return new Rule(opts);
+};
+
+/**
+ * Method to overwrite the message of a rule.
+ * Useful if you'd like to use a built-in, but want to change the ultimate message
+ * that comes out of a failed check.
+ * @param message
+ */
+const withMessage = (message: string | ((v?: any) => string)) => (
+  rule: ValidationRule
+) => {
+  rule.opts.message = message;
+
+  return rule;
+};
+
+export { Rule, createRule, withMessage };

--- a/src/rule.ts
+++ b/src/rule.ts
@@ -54,9 +54,11 @@ const createRule: (opts: CustomValidatorOptions) => ValidationRule = (opts) => {
 const withMessage = (message: string | ((v?: any) => string)) => (
   rule: ValidationRule
 ) => {
-  rule.opts.message = message;
+  const copiedRule = { ...rule };
 
-  return rule;
+  copiedRule.opts.message = message;
+
+  return copiedRule;
 };
 
 export { Rule, createRule, withMessage };

--- a/src/rules/get-prop.ts
+++ b/src/rules/get-prop.ts
@@ -5,12 +5,14 @@
  * @license MIT
  */
 
-import { Fail } from '../fail';
-import { Success } from '../success';
+import { createRule } from '../rule';
 import { hasProp } from './has-prop';
 
-export const getProp = (property) => (obj) =>
-  hasProp(property)(obj).fold({
-    onSuccess: () => new Success(obj[property]),
-    onFail: () => new Fail(`Property '${property}' does not exist`),
+export const getProp = (property) =>
+  createRule({
+    condition: (obj) => hasProp(property).check(obj).isSuccess,
+    message: `Property '${property}' does not exist`,
+    // transform the object to the value of the successfully found property
+    // before handing off to the next check / function.
+    transform: (obj) => obj[property],
   });

--- a/src/rules/greater-than.ts
+++ b/src/rules/greater-than.ts
@@ -5,7 +5,7 @@
  * @license MIT
  */
 
-import { createRule } from '../validation';
+import { createRule } from '../rule';
 
 export const greaterThan = (min) =>
   createRule({

--- a/src/rules/has-prop.ts
+++ b/src/rules/has-prop.ts
@@ -4,12 +4,14 @@
  * @author Nick Krause
  * @license MIT
  */
-import { createRule } from '../validation';
+import { createRule } from '../rule';
 
 export const hasProp = (property) =>
   createRule({
     condition: (obj) => obj.hasOwnProperty(property),
     message: (obj) => {
+      // list out the keys that we have
+      // to help us spot where things may have gone wrong prior
       const keys = Object.keys(obj)
         .toString()
         .replace(',', ', ');

--- a/src/rules/is-array.ts
+++ b/src/rules/is-array.ts
@@ -4,7 +4,7 @@
  * @author Nick Krause
  * @license MIT
  */
-import { createRule } from '../validation';
+import { createRule } from '../rule';
 
 export const isArray = createRule({
   condition: (maybeArr) => Array.isArray(maybeArr),

--- a/src/rules/is-non-empty-array.ts
+++ b/src/rules/is-non-empty-array.ts
@@ -3,11 +3,9 @@
  * @author Nick Krause
  * @license MIT
  */
-import { Fail } from '../fail';
-import { Success } from '../success';
-import { isArray } from './is-array';
+import { createRule } from '../rule';
 
-export const isNonEmptyArray = (maybeArr) =>
-  isArray(maybeArr).chain((arr) =>
-    arr.length ? Success.of(arr) : Fail.of(arr)
-  );
+export const isNonEmptyArray = createRule({
+  condition: (arr) => Array.isArray(arr) && !!arr.length,
+  message: (val) => `No array values found in ${val}`,
+});

--- a/src/rules/is-non-empty-object.ts
+++ b/src/rules/is-non-empty-object.ts
@@ -3,13 +3,17 @@
  * @author Nick Krause
  * @license MIT
  */
-import { Fail } from '../fail';
-import { Success } from '../success';
-import { isObject } from './is-object';
+import { createRule } from '../rule';
 
-export const isNonEmptyObject = (maybeObj: any) =>
-  isObject(maybeObj).chain((obj) =>
-    Object.keys(obj).length
-      ? Success.of(obj)
-      : Fail.of(`Object has no properties.`)
-  );
+export const isNonEmptyObject = createRule({
+  // Reflect.ownKeys is used because
+  // this check should not fail if we only have
+  // properties that are non-enumerable
+  // like 'Symbol' or properties defined by Object.defineProperty where
+  // 'enumerable' is set to false.
+  condition: (obj) => typeof obj === 'object' && !!Reflect.ownKeys(obj).length,
+  message: (obj) =>
+    typeof obj === 'object'
+      ? `Value ${obj} is not a non–empty object`
+      : `Value is not an object`,
+});

--- a/src/rules/is-number.ts
+++ b/src/rules/is-number.ts
@@ -5,9 +5,10 @@
  * @license MIT
  */
 
-import { createRule } from '../validation';
+import { createRule } from '../rule';
 
 export const isNumber = createRule({
-  condition: (maybeNum) => typeof maybeNum === 'number',
+  condition: (maybeNum) =>
+    typeof maybeNum === 'number' && !Number.isNaN(maybeNum),
   message: (notNum) => `Value ${notNum} is not a number.`,
 });

--- a/src/rules/is-object.ts
+++ b/src/rules/is-object.ts
@@ -4,7 +4,7 @@
  * @author Nick Krause
  * @license MIT
  */
-import { createRule } from '../validation';
+import { createRule } from '../rule';
 
 export const isObject = createRule({
   condition: (obj) => typeof obj === 'object',

--- a/src/rules/is-string.ts
+++ b/src/rules/is-string.ts
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { createRule } from '../validation';
+import { createRule } from '../rule';
 
 export const isString = createRule({
   condition: (maybeStr) => typeof maybeStr === 'string',
-  message: (notStr) => `Value ${notStr.toString()} is not a string.`,
+  message: (notStr) => `Value ${notStr} is not a string.`,
 });

--- a/src/rules/less-than.ts
+++ b/src/rules/less-than.ts
@@ -4,7 +4,7 @@
  * @author Nick Krause
  * @license MIT
  */
-import { createRule } from '../validation';
+import { createRule } from '../rule';
 
 /**
  * Rule to validate a number that must be less than some amount.

--- a/src/rules/max-length.ts
+++ b/src/rules/max-length.ts
@@ -1,4 +1,4 @@
-import { createRule } from '../validation';
+import { createRule } from '../rule';
 
 /**
  * Function to ensure that a string is below or equal to a certain length.

--- a/src/rules/min-length.ts
+++ b/src/rules/min-length.ts
@@ -1,4 +1,4 @@
-import { createRule } from '../validation';
+import { createRule } from '../rule';
 
 export const minLength = (length) =>
   createRule({

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,6 +6,12 @@ export interface Validator {
   then(opts: ValidationActions): any;
 }
 
+export interface ValidationRule {
+  message: string | ((v?: any) => string);
+  opts: CustomValidatorOptions;
+  check(v: any): ValidationM;
+}
+
 export interface ValidationActions {
   onSuccess: (v: any) => any;
   onFail: (v: string[]) => any;
@@ -14,6 +20,13 @@ export interface ValidationActions {
 export interface CustomValidatorOptions {
   condition: (v: any) => boolean;
   message: string | ((v: any) => string);
+  // function to ensure delayed execution
+  // so that we don't get any accidental
+  // access errors in the middle of
+  // a long list of checks.
+  // value works the same way as condition,
+  // using the value being checked as an argument.
+  transform?: (v: any) => any;
 }
 
 export type ValidationM = Success | Fail;
@@ -34,6 +47,6 @@ export interface Success {
   fold(opts: ValidationActions): any;
 }
 
-export type ValidationRule = (v: any) => ValidationM;
+export type ValidationCheck = (v: any) => ValidationM;
 export type ValidationRuleset = ValidationRule[];
 export type ValidationErrorMessage = (fn: (v: any) => any) => string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,7 +4,7 @@
  * @author Nick Krause
  * @license MIT
  */
-import { ValidationM, ValidationRule, ValidationRuleset } from './types';
+import { ValidationCheck, ValidationM, ValidationRuleset } from './types';
 
 class ValidationError extends Error {}
 
@@ -15,7 +15,7 @@ class ValidationError extends Error {}
  */
 const id = (x: any) => x;
 
-const pipeValidators: (fns: ValidationRuleset) => ValidationRule = (fns) => (
+const pipeValidators: (fns: ValidationRuleset) => ValidationCheck = (fns) => (
   value: any
 ) => {
   const [first, ...rest] = fns;
@@ -23,7 +23,10 @@ const pipeValidators: (fns: ValidationRuleset) => ValidationRule = (fns) => (
   // starting with the first function that returns a monad,
   // we chain through the rest of the functions
   // in order to combine them all into a single check.
-  return rest.reduce((prevM, nextM) => prevM.chain(nextM), first(value));
+  return rest.reduce(
+    (prevM, nextM) => prevM.chain(nextM.check),
+    first.check(value)
+  );
 };
 
 /**

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -1,7 +1,5 @@
-import { Fail } from './fail';
-import { Success } from './success';
+import { Rule } from './rule';
 import {
-  CustomValidatorOptions,
   ValidationActions,
   ValidationM,
   ValidationRule,
@@ -14,19 +12,6 @@ import { pipeValidators, ValidationError } from './utils';
  * based on the passing of a supplied condition
  *
  */
-const createRule: (opts: CustomValidatorOptions) => ValidationRule = (opts) => (
-  value
-) => {
-  if (opts.condition(value)) {
-    return Success.of(value);
-  } else {
-    if (typeof opts.message === 'function') {
-      return Fail.of(opts.message(value));
-    }
-
-    return Fail.of(opts.message);
-  }
-};
 
 class Validator implements Validator {
   static of(...rules: ValidationRuleset) {
@@ -66,4 +51,4 @@ class Validator implements Validator {
   }
 }
 
-export { createRule, Validator };
+export { Validator };


### PR DESCRIPTION
## PR Type
- [ ] Bug
- [x] Feature

## Requirements
- [X] Wrote tests.
- [X] Updated docs and upgrade instructions, if necessary.

## Rationale

Because many projects use internationalization, and sometimes the built-in messages don't cover all cases, the implementation has been changed to allow a `withMessage` function to allow developers to change the message of an existing check, without changing the original check.

This PR rewrites several internals to allow for this, and updates the docs accordingly. Some extra items missed earlier were included in the README.

To adhere types to the new rewrite, built-in rules were trekked through and rewritten with `createRule` when applicable. `createRule` has also been given an optional 'transform' property that allows us to change the value before handing off to the next validation object, in cases like `getProp` where such actions are necessary to drill down into nested objects.

## Implementation

`createRule` was implemented as an arrow function. The new implementation changes it to a class-based approached in order to allow changes to its inner scope. The new `Rule` class itself is not exposed, only a controlled API that allows developers to customize its operations as needed.

