### PR TITLE
feat(CI):update node CI version to active LTSs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
-  - '10'
-  - '12'
+  - 'lts/*'
 cache: yarn
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - '8'
   - '10'
+  - '12'
 cache: yarn
 notifications:
   email: false


### PR DESCRIPTION
_If there is a linked issue, mention it here._

- [ ] Bug
- [X] Feature

## Requirements

- [X] Read the [contribution guidelines](./.github/CONTRIBUTING.md).
- [N/A]  Wrote tests.
- [N/A] Updated docs and upgrade instructions, if necessary.

## Rationale

_Why is this PR necessary?_

This PR updates the existing travis.yml to build via node 10 and 12 as these versions are the current and next active LTS releases. Node 8 is in maintenance LTS and will be phased out by the end of the year. 

In practice, this is more for dependabot to be able to update packages for security reasons via yarn without hitting node version errors than can prevent us from getting a security update in the dependencies.