### PR TITLE
fix(rules): fix object rules throwing when objects are null

### DIFF
--- a/src/rules/is-non-empty-object.ts
+++ b/src/rules/is-non-empty-object.ts
@@ -12,7 +12,7 @@ export const isNonEmptyObject = createRule({
   // like 'Symbol' or properties defined by Object.defineProperty where
   // 'enumerable' is set to false.
   condition: (obj) =>
-    typeof obj === `object` && Boolean(Reflect.ownKeys(obj).length),
+    !!obj && typeof obj === `object` && Boolean(Reflect.ownKeys(obj).length),
   message: (obj) =>
     typeof obj === `object`
       ? `Object must not be empty`

--- a/src/rules/is-object.ts
+++ b/src/rules/is-object.ts
@@ -8,6 +8,6 @@ import { createRule } from '../rule'
 
 export const isObject = createRule({
   condition: (obj) =>
-    typeof obj === `object` && !Array.isArray(obj) && Boolean(obj),
+    !!obj && typeof obj === `object` && !Array.isArray(obj) && obj === Object(obj),
   message: (notObj) => `Value must be an object, but has type ${typeof notObj}`,
 })


### PR DESCRIPTION
_If there is a linked issue, mention it here._

- [x ] Bug
- [ ] Feature

## Requirements

- [ x] Read the [contribution guidelines](./.github/CONTRIBUTING.md).
- [ x] Wrote tests.
- [ x] Updated docs and upgrade instructions, if necessary.

## Rationale

This PR fixes a bug where null values fed into `isNonEmptyObject` would throw an error

